### PR TITLE
More fixes to Qt6 version

### DIFF
--- a/src/core/package_manager.cpp
+++ b/src/core/package_manager.cpp
@@ -69,8 +69,9 @@ void PackageManager::installPackage(const QString& packageName, const QString& r
     Logger::info(QString("Installing package: %1 from %2").arg(packageName, repository.isEmpty() ? "default" : repository));
     emit operationStarted(QString("Installing %1...").arg(packageName));
     
-    // Determine if this is an AUR package
-    bool isAUR = repository.toLower() == "aur";
+    // Determine if this is an AUR package (not from official repos or chaotic-aur)
+    QString repoLower = repository.toLower();
+    bool isAUR = repoLower == "aur";
     QString helper = getHelperName();
     
     QString command;
@@ -78,7 +79,7 @@ void PackageManager::installPackage(const QString& packageName, const QString& r
         // AUR packages - run helper as regular user (no pkexec)
         command = QString("%1 -S %2 --noconfirm").arg(helper, packageName);
     } else {
-        // Official repos need root access
+        // Official repos and chaotic-aur need root access and use pacman
         command = QString("pkexec pacman -S %1 --noconfirm").arg(packageName);
     }
     
@@ -103,8 +104,9 @@ void PackageManager::updatePackage(const QString& packageName, const QString& re
     Logger::info(QString("Updating package: %1 from %2").arg(packageName, repository.isEmpty() ? "default" : repository));
     emit operationStarted(QString("Updating %1...").arg(packageName));
     
-    // Determine if this is an AUR package
-    bool isAUR = repository.toLower() == "aur";
+    // Determine if this is an AUR package (not from official repos or chaotic-aur)
+    QString repoLower = repository.toLower();
+    bool isAUR = repoLower == "aur";
     QString helper = getHelperName();
     
     QString command;
@@ -112,7 +114,7 @@ void PackageManager::updatePackage(const QString& packageName, const QString& re
         // AUR packages - run helper as regular user (no pkexec)
         command = QString("%1 -S %2 --noconfirm").arg(helper, packageName);
     } else {
-        // Official repos need root access
+        // Official repos and chaotic-aur need root access and use pacman
         command = QString("pkexec pacman -S %1 --noconfirm").arg(packageName);
     }
     

--- a/src/gui/home_widget.cpp
+++ b/src/gui/home_widget.cpp
@@ -49,7 +49,7 @@ void HomeWidget::setupUi() {
 }
 
 void HomeWidget::loadFeaturedPackages() {
-    // Featured packages list
+    // Featured packages list with initial repositories
     m_featuredPackages = {
         {"firefox", "Latest", "Fast, Private & Safe Web Browser", "extra"},
         {"gimp", "Latest", "GNU Image Manipulation Program", "extra"},
@@ -64,6 +64,21 @@ void HomeWidget::loadFeaturedPackages() {
         {"libreoffice-still", "Latest", "Free and Open Source Office Suite", "extra"},
         {"zoom", "Latest", "Video Conferencing and Web Conferencing Service", "AUR"}
     };
+    
+    // Check if packages marked as AUR are actually available in automated repos (like chaotic-aur)
+    for (auto& pkg : m_featuredPackages) {
+        if (pkg.repository.toLower() == "aur") {
+            PackageInfo repoInfo = AlpmWrapper::instance().getPackageInfo(pkg.name);
+            if (!repoInfo.name.isEmpty() && !repoInfo.repository.isEmpty()) {
+                // Package found in automated repos, use that repository instead
+                pkg.repository = repoInfo.repository;
+                pkg.version = repoInfo.version;
+                pkg.description = repoInfo.description;
+                Logger::info(QString("Package %1 found in %2 repository, using pacman instead of AUR helper")
+                            .arg(pkg.name, pkg.repository));
+            }
+        }
+    }
     
     Logger::info(QString("Loaded %1 featured packages").arg(m_featuredPackages.size()));
 }

--- a/src/gui/home_widget.cpp
+++ b/src/gui/home_widget.cpp
@@ -68,14 +68,17 @@ void HomeWidget::loadFeaturedPackages() {
     // Check if packages marked as AUR are actually available in automated repos (like chaotic-aur)
     for (auto& pkg : m_featuredPackages) {
         if (pkg.repository.toLower() == "aur") {
+            Logger::debug(QString("Checking if AUR package %1 is available in official repos...").arg(pkg.name));
             PackageInfo repoInfo = AlpmWrapper::instance().getPackageInfo(pkg.name);
             if (!repoInfo.name.isEmpty() && !repoInfo.repository.isEmpty()) {
                 // Package found in automated repos, use that repository instead
                 pkg.repository = repoInfo.repository;
                 pkg.version = repoInfo.version;
                 pkg.description = repoInfo.description;
-                Logger::info(QString("Package %1 found in %2 repository, using pacman instead of AUR helper")
+                Logger::info(QString("✅ Package %1 found in %2 repository, will use pacman instead of AUR helper")
                             .arg(pkg.name, pkg.repository));
+            } else {
+                Logger::debug(QString("Package %1 not found in official repos, will use AUR helper").arg(pkg.name));
             }
         }
     }

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -17,15 +17,15 @@ MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent)
     , m_tabWidget(std::make_unique<QTabWidget>(this)) {
     
-    setupUi();
-    loadStyleSheet();
-    
-    // Initialize ALPM
+    // Initialize ALPM before creating widgets that might need it
     if (!AlpmWrapper::instance().initialize()) {
         QMessageBox::critical(this, "Error", 
             "Failed to initialize package manager. Please check your system configuration.");
         Logger::error("Failed to initialize ALPM in MainWindow");
     }
+    
+    setupUi();
+    loadStyleSheet();
     
     Logger::info("MainWindow created successfully");
 }

--- a/src/gui/settings_widget.cpp
+++ b/src/gui/settings_widget.cpp
@@ -7,6 +7,8 @@
 #include <QFile>
 #include <QTextStream>
 #include <QProcess>
+#include <QScrollArea>
+#include <QWidget>
 
 SettingsWidget::SettingsWidget(QWidget* parent)
     : QWidget(parent)
@@ -18,6 +20,9 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     , m_chaoticAurGroup(nullptr)
     , m_setupChaoticButton(nullptr)
     , m_removeChaoticButton(nullptr)
+    , m_maintenanceGroup(nullptr)
+    , m_removeLockButton(nullptr)
+    , m_syncReposButton(nullptr)
     , m_applyButton(nullptr)
     , m_revertButton(nullptr)
     , m_statusLabel(nullptr)
@@ -31,11 +36,25 @@ SettingsWidget::SettingsWidget(QWidget* parent)
 }
 
 void SettingsWidget::setupUi() {
-    auto* mainLayout = new QVBoxLayout(this);
+    // Create main layout for the widget
+    auto* outerLayout = new QVBoxLayout(this);
+    outerLayout->setContentsMargins(0, 0, 0, 0);
+    
+    // Create scroll area
+    auto* scrollArea = new QScrollArea(this);
+    scrollArea->setWidgetResizable(true);
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    
+    // Create content widget that will be scrollable
+    auto* contentWidget = new QWidget();
+    auto* mainLayout = new QVBoxLayout(contentWidget);
     mainLayout->setSpacing(20);
+    mainLayout->setContentsMargins(10, 10, 10, 10);
     
     // Title
-    auto* titleLabel = new QLabel("Settings", this);
+    auto* titleLabel = new QLabel("Settings", contentWidget);
     auto titleFont = titleLabel->font();
     titleFont.setPointSize(24);
     titleFont.setBold(true);
@@ -55,7 +74,7 @@ void SettingsWidget::setupUi() {
     mainLayout->addWidget(m_maintenanceGroup);
     
     // Status label
-    m_statusLabel = new QLabel(this);
+    m_statusLabel = new QLabel(contentWidget);
     m_statusLabel->setAlignment(Qt::AlignCenter);
     m_statusLabel->setStyleSheet("QLabel { color: #0066cc; padding: 10px; }");
     m_statusLabel->hide();
@@ -65,13 +84,13 @@ void SettingsWidget::setupUi() {
     auto* buttonLayout = new QHBoxLayout();
     buttonLayout->addStretch();
     
-    m_revertButton = new QPushButton("Revert", this);
+    m_revertButton = new QPushButton("Revert", contentWidget);
     m_revertButton->setMinimumWidth(100);
     m_revertButton->setEnabled(false);
     connect(m_revertButton, &QPushButton::clicked, this, &SettingsWidget::onRevertClicked);
     buttonLayout->addWidget(m_revertButton);
     
-    m_applyButton = new QPushButton("Apply", this);
+    m_applyButton = new QPushButton("Apply", contentWidget);
     m_applyButton->setMinimumWidth(100);
     m_applyButton->setEnabled(false);
     connect(m_applyButton, &QPushButton::clicked, this, &SettingsWidget::onApplyClicked);
@@ -82,7 +101,13 @@ void SettingsWidget::setupUi() {
     // Add stretch at the bottom
     mainLayout->addStretch();
     
-    setLayout(mainLayout);
+    // Set the content widget to the scroll area
+    scrollArea->setWidget(contentWidget);
+    
+    // Add scroll area to the outer layout
+    outerLayout->addWidget(scrollArea);
+    
+    setLayout(outerLayout);
 }
 
 void SettingsWidget::createRepositorySettings() {
@@ -257,6 +282,39 @@ void SettingsWidget::createMaintenanceSettings() {
     lockInfoLabel->setWordWrap(true);
     lockInfoLabel->setStyleSheet("QLabel { color: #888; font-size: 11px; margin-top: 5px; margin-left: 10px; }");
     maintenanceLayout->addWidget(lockInfoLabel);
+    
+    // Spacer
+    maintenanceLayout->addSpacing(15);
+    
+    // Sync repositories section
+    auto* syncReposLayout = new QHBoxLayout();
+    
+    auto* syncReposLabel = new QLabel(
+        "Synchronize Repositories:",
+        this);
+    syncReposLabel->setStyleSheet("QLabel { font-weight: bold; }");
+    syncReposLayout->addWidget(syncReposLabel);
+    
+    syncReposLayout->addStretch();
+    
+    m_syncReposButton = new QPushButton("Sync Repositories", this);
+    m_syncReposButton->setMinimumWidth(150);
+    m_syncReposButton->setToolTip(
+        "Manually synchronize package databases (pacman -Sy).\n"
+        "This updates the list of available packages from all enabled repositories.");
+    connect(m_syncReposButton, &QPushButton::clicked, this, &SettingsWidget::onSyncReposClicked);
+    syncReposLayout->addWidget(m_syncReposButton);
+    
+    maintenanceLayout->addLayout(syncReposLayout);
+    
+    // Sync info
+    auto* syncInfoLabel = new QLabel(
+        "Use this to manually update your package database. This is useful after enabling/disabling repositories\n"
+        "or when you want to ensure you have the latest package information.",
+        this);
+    syncInfoLabel->setWordWrap(true);
+    syncInfoLabel->setStyleSheet("QLabel { color: #888; font-size: 11px; margin-top: 5px; margin-left: 10px; }");
+    maintenanceLayout->addWidget(syncInfoLabel);
     
     m_maintenanceGroup->setLayout(maintenanceLayout);
 }
@@ -968,4 +1026,60 @@ void SettingsWidget::onRemoveChaoticClicked() {
     
     process->start("pkexec", QStringList() << "pacman" << "-Rns" << "--noconfirm" 
                    << "chaotic-keyring" << "chaotic-mirrorlist");
+}
+
+void SettingsWidget::onSyncReposClicked() {
+    QMessageBox msgBox(this);
+    msgBox.setIcon(QMessageBox::Question);
+    msgBox.setWindowTitle("Sync Repositories");
+    msgBox.setText("Synchronize package databases?");
+    msgBox.setInformativeText(
+        "This will run: pacman -Sy\n\n"
+        "This updates the list of available packages from all enabled repositories.\n"
+        "This is useful after enabling/disabling repositories or when you want to "
+        "ensure you have the latest package information.");
+    msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+    msgBox.setDefaultButton(QMessageBox::Yes);
+    
+    if (msgBox.exec() != QMessageBox::Yes) {
+        return;
+    }
+    
+    m_statusLabel->setText("Synchronizing repositories...");
+    m_statusLabel->setStyleSheet("QLabel { color: #0066cc; padding: 10px; }");
+    m_statusLabel->show();
+    m_syncReposButton->setEnabled(false);
+    
+    // Run pacman -Sy with pkexec
+    QProcess* process = new QProcess(this);
+    connect(process, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+            this, [this, process](int exitCode, QProcess::ExitStatus exitStatus) {
+        process->deleteLater();
+        m_syncReposButton->setEnabled(true);
+        
+        if (exitCode == 0 && exitStatus == QProcess::NormalExit) {
+            m_statusLabel->setText("Repositories synchronized successfully!");
+            m_statusLabel->setStyleSheet("QLabel { color: #00aa00; padding: 10px; font-weight: bold; }");
+            m_statusLabel->show();
+            Logger::info("Repositories synchronized successfully");
+            
+            // Refresh ALPM databases
+            AlpmWrapper::instance().refreshDatabases();
+            
+            QMessageBox::information(this, "Success",
+                "Package databases synchronized successfully!\n\n"
+                "The package list has been updated with the latest available packages.");
+        } else {
+            m_statusLabel->setText("Failed to synchronize repositories.");
+            m_statusLabel->setStyleSheet("QLabel { color: #aa0000; padding: 10px; }");
+            m_statusLabel->show();
+            Logger::error("Failed to synchronize repositories");
+            
+            QMessageBox::critical(this, "Error",
+                "Failed to synchronize package databases.\n"
+                "Please check your internet connection and try again.");
+        }
+    });
+    
+    process->start("pkexec", QStringList() << "pacman" << "-Sy");
 }

--- a/src/gui/settings_widget.h
+++ b/src/gui/settings_widget.h
@@ -51,6 +51,7 @@ private:
     // Maintenance settings
     QGroupBox* m_maintenanceGroup;
     QPushButton* m_removeLockButton;
+    QPushButton* m_syncReposButton;
     
     // Control buttons
     QPushButton* m_applyButton;
@@ -70,6 +71,7 @@ private slots:
     void onSetupChaoticClicked();
     void onRemoveChaoticClicked();
     void onRemoveLockClicked();
+    void onSyncReposClicked();
 };
 
 #endif // SETTINGS_WIDGET_H


### PR DESCRIPTION
This PR does the following things:
1. Initialize alpm before setting up the UI
2. Add a sync tab for manual synchronization in settings.
3. Use chaotic everywhere for AUR if enabled.