### PR TITLE
fix: typing lag in search and preserve results after dialog close

### DIFF
--- a/src/gui/installed_widget.cpp
+++ b/src/gui/installed_widget.cpp
@@ -16,8 +16,16 @@ InstalledWidget::InstalledWidget(QWidget* parent)
     , m_contentWidget(new QWidget())
     , m_gridLayout(new QGridLayout(m_contentWidget))
     , m_statusLabel(new QLabel(this))
-    , m_countLabel(new QLabel(this)) {
-    
+    , m_countLabel(new QLabel(this)) 
+    , m_filterTimer(new QTimer(this)) {
+
+    // debounce timer (waits 300ms after last keystroke)
+    m_filterTimer->setSingleShot(true);
+    m_filterTimer->setInterval(300);
+    connect(m_filterTimer, &QTimer::timeout, this, [this]() {
+        filterPackages(m_filterInput->text());
+    });
+
     setupUi();
     loadInstalledPackages();
 }
@@ -84,7 +92,7 @@ void InstalledWidget::loadInstalledPackages() {
             m_countLabel->setText(QString("%1 packages installed")
                                  .arg(packages.size()));
             
-            displayPackages(packages);
+            filterPackages(m_filterInput->text());
             
             Logger::info(QString("Loaded %1 installed packages").arg(packages.size()));
         }, Qt::QueuedConnection);
@@ -158,16 +166,18 @@ void InstalledWidget::filterPackages(const QString& query) {
 }
 
 void InstalledWidget::onFilterTextChanged(const QString& text) {
-    filterPackages(text);
+    Q_UNUSED(text);
+    m_filterTimer->start();
 }
 
 void InstalledWidget::onPackageClicked(const PackageInfo& info) {
     Logger::info(QString("Package clicked: %1").arg(info.name));
     
     auto* dialog = new PackageDetailsDialog(info, this);
-    dialog->exec();
+    if(dialog->exec() == QDialog::Accepted) {
+      // Refresh after dialog closes in case package was uninstalled
+      refreshPackages();
+    }
+
     dialog->deleteLater();
-    
-    // Refresh after dialog closes in case package was uninstalled
-    refreshPackages();
 }

--- a/src/gui/installed_widget.h
+++ b/src/gui/installed_widget.h
@@ -6,6 +6,7 @@
 #include <QGridLayout>
 #include <QLineEdit>
 #include <QLabel>
+#include <QTimer>
 #include <QVector>
 #include "../utils/types.h"
 
@@ -42,6 +43,8 @@ private:
     
     QVector<PackageInfo> m_allPackages;
     QVector<PackageInfo> m_filteredPackages;
+
+    QTimer* m_filterTimer;
     
 private slots:
     void onPackageClicked(const PackageInfo& info);

--- a/src/gui/package_details_dialog.cpp
+++ b/src/gui/package_details_dialog.cpp
@@ -321,7 +321,7 @@ void PackageDetailsDialog::setupUi() {
     
     m_closeButton->setMinimumWidth(100);
     m_closeButton->setMinimumHeight(35);
-    connect(m_closeButton, &QPushButton::clicked, this, &QDialog::accept);
+    connect(m_closeButton, &QPushButton::clicked, this, &QDialog::reject);
     buttonLayout->addWidget(m_closeButton);
     
     dialogLayout->addWidget(buttonWidget, 0);


### PR DESCRIPTION
- Added a 300ms timer to search input for preventing UI freezing on every keystroke in installed packages tab
- Update loadInstalledPackages to keep the current filter text and results